### PR TITLE
Initially display only DateTime formats

### DIFF
--- a/src/Components/Diagram.js
+++ b/src/Components/Diagram.js
@@ -5,11 +5,11 @@ import { getCurrentTimezoneOffset } from "../util/timeZone";
 
 function Diagram (props) {
   const { date, rfc = true, iso = true, html = false, showKey = false, ...restProps } = props;
-  const [ showDate, setShowDate ] = React.useState(true);
-  const [ showTime, setShowTime ] = React.useState(true);
+  const [ showDate, setShowDate ] = React.useState(false);
+  const [ showTime, setShowTime ] = React.useState(false);
   const [ showDateTime, setShowDateTime ] = React.useState(true);
-  const [ showPeriod, setShowPeriod ] = React.useState(true);
-  const [ showRange, setShowRange ] = React.useState(true);
+  const [ showPeriod, setShowPeriod ] = React.useState(false);
+  const [ showRange, setShowRange ] = React.useState(false);
 
   const timeZone = React.useContext(TimeZoneContext);
 


### PR DESCRIPTION
This:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/44704949/219899927-9f393f15-ef5e-4e80-a63b-21b6b35eb6e4.png">

Instead of:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/44704949/219900003-083fc2e5-f0b8-425c-ad64-4855c9a4d71d.png">
