### PR TITLE
Show colorized time granularities by default

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import { TimeZonePicker } from './Components/TimeZonePicker';
 import { getBrowserTimezone } from './util/timeZone';
 import TimeZoneContext from './TimeZoneContext';
 
-function App ({ initialDate = null, initalShowISO = true, initalShowRFC = true, initalShowHTML = false, initalShowColours = false, readOnlyMode = false, showDiagram = true }) {
+function App ({ initialDate = null, initalShowISO = true, initalShowRFC = true, initalShowHTML = false, initalShowColours = true, readOnlyMode = false, showDiagram = true }) {
   const [ now, setNow ] = useState(() => (initialDate || new Date()));
   const [ showISO, setShowISO ] = useSavedState("rfciso.showISO", initalShowISO);
   const [ showRFC, setShowRFC ] = useSavedState("rfciso.showRFC", initalShowRFC);


### PR DESCRIPTION
Like this:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/44704949/219901378-a855585e-cd0a-4ec2-b33a-aa519f0c7b82.png">

Instead of this:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/44704949/219901390-90066937-4aa7-4424-bfa2-10007a4e370d.png">
