### PR TITLE
Don't even pass showColours as a parameter to the Diagram

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -71,7 +71,7 @@ function App ({ initialDate = null, initalShowISO = true, initalShowRFC = true, 
                 </label>
               </p>
             }
-            <Diagram date={now} iso={showISO} rfc={showRFC} html={showHTML} showKey={showColours} showSix={showSixDigitYears} />
+            <Diagram date={now} iso={showISO} rfc={showRFC} html={showHTML} showSix={showSixDigitYears} />
           </>
         }
         <h2 style={{marginBottom:0}}>Format Listing</h2>


### PR DESCRIPTION
Observing some buggy rendering like this, but not sure what makes it come up:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/44704949/219904397-f9dd0b3f-6b1d-4479-acbf-a8af5cfe0f64.png">

That should be this instead:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/44704949/219904414-9eff3471-b1c9-4799-b7a1-f041c4399872.png">

I don't know if this small change will fix it or not, but local testing suggested that it shouldn't make it worse.